### PR TITLE
Changes cloud run image tag to RELEASE_TAG

### DIFF
--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.17.1]
 
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.17.1]
     steps:
       - name: Checkout latest code in main
         uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
       - name: Deploy
         run: |-
           gcloud components install beta --quiet
-          gcloud beta run deploy $REPO_NAME --image gcr.io/$CLOUD_RUN_PROJECT_ID/$REPO_NAME:$GITHUB_SHA \
+          gcloud beta run deploy $REPO_NAME --image gcr.io/$CLOUD_RUN_PROJECT_ID/$REPO_NAME:$RELEASE_TAG \
             --project $CLOUD_RUN_PROJECT_ID \
             --platform managed \
             --region $CLOUD_RUN_REGION \


### PR DESCRIPTION
...and hard codes the required version to prevent the
npm ERR cb() never called error during the rest stage